### PR TITLE
Merge package.json's "binary" entry instead of overwriting

### DIFF
--- a/pre-gypify.js
+++ b/pre-gypify.js
@@ -1,47 +1,49 @@
 #!/usr/bin/env node
 
-var fs = require('fs')
+var fs = require("fs");
 var opts = require("nomnom").parse();
-var gyp = require('gyp-reader');
+var gyp = require("gyp-reader");
 
-gyp('./binding.gyp', function (err, data) {
-  setImmediate(function () {
-    var targetName = data.targets.filter(function (target) {
-      return !target.type;
-    })[0].target_name;
+gyp("./binding.gyp", function (err, data) {
+  var targetName = data.targets.filter(function (target) {
+    return !target.type;
+  })[0].target_name;
 
-    if (!data.targets.some(function (target) {
-      return target.target_name == 'action_after_build'
-    })) {
-      console.error('adding action_after_build...');
-      (data.targets || []).push({
-        "target_name": "action_after_build",
-        "type": "none",
-        "dependencies": [ "<(module_name)" ],
-        "copies": [
-        {
-          "files": [ "<(PRODUCT_DIR)/<(module_name).node" ],
-          "destination": "<(module_path)"
-        }
-        ]
-      });
-      console.error('writing binding.gyp...');
-      fs.writeFileSync('./binding.gyp', JSON.stringify(data, null, '  '));
-    }
+  if (!data.targets.some(function (target) {
+    return target.target_name == "action_after_build"
+  })) {
+    console.error("adding action_after_build...");
+    (data.targets || []).push({
+      "target_name": "action_after_build",
+      "type": "none",
+      "dependencies": [ "<(module_name)" ],
+      "copies": [
+      {
+        "files": [ "<(PRODUCT_DIR)/<(module_name).node" ],
+        "destination": "<(module_path)"
+      }
+      ]
+    });
+    console.error("writing binding.gyp...");
+    fs.writeFileSync("./binding.gyp", JSON.stringify(data, null, "  "));
+  }
 
-    var pack = JSON.parse(fs.readFileSync('./package.json', 'utf-8'));
-    console.error('writing package.json...');
-    if (!pack.binary) {
-      pack.binary = {
-        "module_name": targetName,
-        "module_path": "out/" + process.config.target_defaults.default_configuration + "/",
-        "host": "example.com",
-      };
-    }
+  var packageJson = JSON.parse(fs.readFileSync("./package.json", "utf-8"));
 
-    pack.binary.package_name = opts.package_name || "{module_name}-v{version}-{node_abi}-{platform}-{arch}.tar.gz";
+  if (!packageJson.binary) {
+    packageJson.binary = {};
+  }
 
-    fs.writeFileSync('package.json', JSON.stringify(pack, null, '  '));
-    console.error('kk');
+  // Merge existing packageJson.binary with ours
+  Object.assign(packageJson.binary, {
+    module_name: targetName,
+    module_path: `out/${process.config.target_defaults.default_configuration}/`,
+    host: "example.com",
   });
+
+  packageJson.binary.package_name = opts.package_name || "{module_name}-v{version}.tar.gz";
+
+  console.error("writing package.json...");
+  fs.writeFileSync("package.json", JSON.stringify(packageJson, null, "  "));
+  console.error("kk");
 });


### PR DESCRIPTION
For modules that already have node-pre-gyp configuration, this tool should respect the existing values of the "binary" entry in package.json and only _merge_ the required changes.

This fixes: 
- https://github.com/voodootikigod/node-serialport/issues/754
- https://github.com/tessel/t2-compiler/issues/21

Can be tested with tessel/t2-compiler#test-pre-gypify-patch

Signed-off-by: Rick Waldron waldron.rick@gmail.com
