### PR TITLE
Log errors from gyp() if any occur

### DIFF
--- a/pre-gypify.js
+++ b/pre-gypify.js
@@ -5,6 +5,9 @@ var opts = require("nomnom").parse();
 var gyp = require("gyp-reader");
 
 gyp("./binding.gyp", function (err, data) {
+  if (err) {
+    console.error(err.stack);
+  }
   var targetName = data.targets.filter(function (target) {
     return !target.type;
   })[0].target_name;


### PR DESCRIPTION
If an error occurs here, it can be really difficult to debug if it's not logged. Unfortunately this doesn't add any error handling, but it's at least something.
